### PR TITLE
Handle empty search in replace to avoid infinite loop

### DIFF
--- a/lib/src/main/java/lt/neworld/spanner/Spanner.kt
+++ b/lib/src/main/java/lt/neworld/spanner/Spanner.kt
@@ -107,6 +107,8 @@ class Spanner(text: CharSequence?) : SpannableStringBuilder(text) {
     }
 
     fun replace(search: CharSequence, replace: CharSequence, vararg spans: Span): Spanner {
+        if (TextUtils.isEmpty(search)) return this
+
         var start: Int
 
         while (true) {

--- a/lib/src/test/java/lt/neworld/spanner/SpannerTest.kt
+++ b/lib/src/test/java/lt/neworld/spanner/SpannerTest.kt
@@ -138,6 +138,13 @@ class SpannerTest {
         )
     }
 
+    @Test
+    fun replace_emptySearch() {
+        val spanner = Spanner("foo")
+        spanner.replace("", "bar")
+        assertEquals("foo", spanner.toString())
+    }
+
     fun assertSpans(expected: String, actual: Spanner) {
         assertEquals(expected, actual.debugSpans())
     }


### PR DESCRIPTION
## Summary
- guard against empty search strings in `Spanner.replace` to prevent infinite loop
- add unit test covering empty search replacement

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac66bf16948323a13918247ee3faaf