### PR TITLE
feat: add furigana span

### DIFF
--- a/lib/src/main/java/lt/neworld/spanner/FuriganaSpan.kt
+++ b/lib/src/main/java/lt/neworld/spanner/FuriganaSpan.kt
@@ -1,0 +1,75 @@
+package lt.neworld.spanner
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.text.style.ReplacementSpan
+
+/**
+ * Span that draws given reading (furigana) above base text.
+ *
+ * @param reading text to draw above
+ * @param relativeSize size of furigana relative to base text size
+ */
+class FuriganaSpan @JvmOverloads constructor(
+    private val reading: String,
+    private val relativeSize: Float = DEFAULT_RELATIVE_SIZE
+) : ReplacementSpan() {
+
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        fm: Paint.FontMetricsInt?
+    ): Int {
+        val base = text.subSequence(start, end).toString()
+        val width = paint.measureText(base).toInt()
+
+        if (fm != null) {
+            val baseFm = paint.fontMetricsInt
+            val rubyPaint = Paint(paint)
+            rubyPaint.textSize = paint.textSize * relativeSize
+            val rubyFm = rubyPaint.fontMetricsInt
+            val extra = rubyFm.bottom - rubyFm.top
+            fm.ascent = baseFm.ascent - extra
+            fm.top = baseFm.top - extra
+            fm.descent = baseFm.descent
+            fm.bottom = baseFm.bottom
+        }
+
+        return width
+    }
+
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint
+    ) {
+        val base = text.subSequence(start, end).toString()
+        // draw base text
+        canvas.drawText(base, x, y.toFloat(), paint)
+
+        val rubyPaint = Paint(paint)
+        rubyPaint.textSize = paint.textSize * relativeSize
+
+        val baseWidth = paint.measureText(base)
+        val rubyWidth = rubyPaint.measureText(reading)
+        val rubyX = x + (baseWidth - rubyWidth) / 2f
+
+        val baseTop = y + paint.fontMetricsInt.ascent
+        val rubyBaseline = baseTop - rubyPaint.fontMetricsInt.descent
+
+        canvas.drawText(reading, rubyX, rubyBaseline.toFloat(), rubyPaint)
+    }
+
+    companion object {
+        const val DEFAULT_RELATIVE_SIZE = 0.5f
+    }
+}
+

--- a/lib/src/main/java/lt/neworld/spanner/FuriganaSpanBuilder.kt
+++ b/lib/src/main/java/lt/neworld/spanner/FuriganaSpanBuilder.kt
@@ -1,0 +1,12 @@
+package lt.neworld.spanner
+
+/**
+ * Builder for [FuriganaSpan].
+ */
+internal class FuriganaSpanBuilder @JvmOverloads constructor(
+    private val reading: String,
+    private val relativeSize: Float = FuriganaSpan.DEFAULT_RELATIVE_SIZE
+) : SpanBuilder {
+    override fun build(): Any = FuriganaSpan(reading, relativeSize)
+}
+

--- a/lib/src/main/java/lt/neworld/spanner/Spans.java
+++ b/lib/src/main/java/lt/neworld/spanner/Spans.java
@@ -56,6 +56,7 @@ import lt.neworld.spanner.Span;
 import lt.neworld.spanner.SpanBuilder;
 import lt.neworld.spanner.StyleSpanBuilder;
 import lt.neworld.spanner.LineBackgroundSpanBuilder;
+import lt.neworld.spanner.FuriganaSpanBuilder;
 
 public class Spans {
     private Spans() {
@@ -162,6 +163,20 @@ public class Spans {
                 return new UnderlineSpan();
             }
         });
+    }
+
+    /**
+     * Creates a span that draws provided reading (furigana) above the base text.
+     */
+    public static Span furigana(@NonNull final String reading) {
+        return new Span(new FuriganaSpanBuilder(reading));
+    }
+
+    /**
+     * Creates a span that draws provided reading (furigana) above the base text using given relative size.
+     */
+    public static Span furigana(@NonNull final String reading, @FloatRange(from = 0.0) final float relativeSize) {
+        return new Span(new FuriganaSpanBuilder(reading, relativeSize));
     }
 
     /**


### PR DESCRIPTION
## Summary
- add FuriganaSpan ReplacementSpan drawing ruby text above base
- provide builder and expose furigana() helpers in Spans

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac69a00f3483238a4ab2eeb0e19e0e