### PR TITLE
Add furigana example to SampleJavaActivity

### DIFF
--- a/sample/src/main/java/lt/neworld/spanner/sample/SampleJavaActivity.java
+++ b/sample/src/main/java/lt/neworld/spanner/sample/SampleJavaActivity.java
@@ -71,6 +71,7 @@ public class SampleJavaActivity extends AppCompatActivity {
                 .append("underline\n", underline())
                 .append("background\n", background(Color.YELLOW))
                 .append("foreground\n", foreground(Color.RED))
+                .append("漢字", Spans.furigana("かんじ")).append("\n")
                 .append("subscript\n", subscript())
                 .append("superscript\n", superscript())
                 .append("Image with custom bounds: ").append(image(drawable)).append("\n")


### PR DESCRIPTION
## Summary
- demonstrate furigana span usage in SampleJavaActivity

## Testing
- `./gradlew :sample:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6b0bc824832389eafeeacba08830